### PR TITLE
Add Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8
+
+RUN pip install --upgrade pip
+
+# Avoid rebuilding this step if no changes to requirements.txt
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Copy everything in the container
+# This expects the models submodule to be present
+COPY . .
+
+EXPOSE 5000
+ENTRYPOINT [ "python", "main.py", "--host", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ python main.py [args]
 
 Then open a web browser to http://localhost:5000
 
+### Run with Docker
+
+Make sure you cloned the `models` submodule before building the Docker image:
+
+```bash
+docker build -t libretranslate .
+```
+
+Run the built image:
+
+```bash
+docker run -it -p 5000:5000 libretranslate [args]
+```
+
+Or build and run using `docker-compose`:
+
+```bash
+docker-compose up -d --build
+```
+
+> Feel free to change the [`docker-compose.yml`](https://github.com/uav4geo/LibreTranslate/blob/main/docker-compose.yml) file to adapt it to your deployment needs, or use an extra `docker-compose.prod.yml` file for your deployment configuration.
+
 ## Arguments
 
 | Argument      | Description                    | Default              |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  libretranslate:
+    container_name: libretranslate
+    build: .
+    restart: unless-stopped
+    ports:
+      - 5000:5000
+    ## Uncomment above command and define your args if necessary
+    # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500 


### PR DESCRIPTION
User-friendly web interface, clear example to query with javascript, and documented using OpenAPI... Thanks a lot for this nicely built service!

I added a `Dockerfile` and `docker-compose.yml` to build and run it as a Docker image. And added the relevant documentation to the `README.md` 

I tried it, translating via the web UI worked well:
* Deployed locally on port 5000
* Deployed on a public server with HTTPS encryption, using my favorite Docker based [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) and its [letsencrypt companion](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion)

Note that I currently let the user built the image (which is convenient for people who wants to change the models), but you might be interested to host it in a Container Registry to make it more straightforward for people who just want to pull and deploy 

I would recommend you using GitHub Package Registry to avoid the new DockerHub limitations that can be a pain when pulling from a cluster

Let me know if you want help with this! Building and publishing new images could be automated easily using GitHub Actions 


Small note, I got this warning about CUDA not finding GPU:

```
Installed 9 language models!
Serving on http://0.0.0.0:5000
/usr/local/lib/python3.8/site-packages/torch/cuda/__init__.py:52: UserWarning: CUDA initialization: Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx (Triggered internally at  /pytorch/c10/cuda/CUDAFunctions.cpp:100.)
  return torch._C._cuda_getDeviceCount() > 0
```

This could be an interesting feature for later, if using GPU makes the translation faster