### PR TITLE
Automated workflows to publish the docker image

### DIFF
--- a/.github/workflows/publish-docker-github.yml
+++ b/.github/workflows/publish-docker-github.yml
@@ -1,0 +1,73 @@
+name: Publish to GitHub Container Registry
+# To uav4geo GitHub Container Registry
+# https://github.com/orgs/uav4geo/packages
+
+on:
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  # Run tests for any PRs.
+  pull_request:
+  # Enable manual trigger.
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: libretranslate
+  # The image ID is generated using the GitHub user ID
+  # In our case IMAGE_ID: ghcr.io/uav4geo/libretranslate
+
+jobs:
+  # Test if the docker image build successfully
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          docker build . --file Dockerfile
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      # Create an access token with `read:packages` and `write:packages` scopes
+      # https://github.com/settings/tokens
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CONTAINER_REGISTRY_GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -1,0 +1,31 @@
+name: Publish to DockerHub
+
+on:
+  push:
+    branches: main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: libretranslate/libretranslate:latest
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I created 2 different GitHub Actions workflows to build and publish the Docker image

## To DockerHub

I used the official build and push action from DockerHub

https://github.com/marketplace/actions/build-and-push-docker-images

It's a simple workflow that will build and push to `libretranslate/libretranslate:latest` at each push to the `main` branch

Secrets to set:

* `DOCKERHUB_USERNAME`
* `DOCKERHUB_TOKEN` (for security most container registries now use token instead of the password, it should be easy to find where to create it)

## To GitHub Action

I used the workflow provided by GitHub (when going to https://github.com/uav4geo/LibreTranslate/actions/new and clicking on `More continuous integration workflows`). With some customizations

It will publish the container at `ghcr.io/uav4geo/libretranslate` following those rules:

1. Publish a new `latest` image at each push to the `main` branch
2. When you create a new release (e.g. `v1.0.1`), it should publish an image for it with the tag `1.0.1` 
3. The workflow will also run a simple `docker build` for every pull request (to make sure the change did not break the docker image before merging)

> Note that you can easily make it simpler if you don't need all those rules, the workflow is heavily documented and easy to edit, especially if you know your Bash basics 

You don't need to create the image, github will create it auto at the first push as a private image though! You will just need to go to your image and **set it to public after the first push**

You will find the LibreTranslate package here on GitHub website: https://github.com/orgs/uav4geo/packages

Secret to set: 

* `CONTAINER_REGISTRY_GITHUB_TOKEN`, create an access token with `read:packages` and `write:packages` scopes at https://github.com/settings/tokens



Personally I stopped publishing to DockerHub due to the new pull rates which are really restrictives and cause issues in our organization, I am using GitHub Container Registry for all my applications at work and personal and never had any issue, even if it's still `beta`. I just hope they will not set pull rates later :) (but the ongoing GitHub policies to promote open source is quite encouraging)

Here an example of what it looks like when an image is published on GitHub: https://github.com/users/vemonet/packages/container/package/jupyterlab