### PR TITLE
Add badges for GitHub Actions workflows in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Try it online!](https://libretranslate.com) | [API Docs](https://libretranslate.com/docs)
 
+[![Publish to DockerHub](https://github.com/uav4geo/LibreTranslate/workflows/Publish%20to%20DockerHub/badge.svg)](https://hub.docker.com/r/libretranslate/libretranslate) ![Publish to GitHub Container Registry](https://github.com/uav4geo/LibreTranslate/workflows/Publish%20to%20GitHub%20Container%20Registry/badge.svg)
+
 Free and Open Source Machine Translation API, entirely self-hosted and works even in offline environments. Unlike other APIs, it doesn't rely on proprietary providers such as Google or Azure to perform translations.
 
 ![image](https://user-images.githubusercontent.com/1951843/102724116-32a6df00-42db-11eb-8cc0-129ab39cdfb5.png)


### PR DESCRIPTION
Added badges for GitHub Actions workflows to build and publish the docker image, and making it a link to find the DockerHub image homepage easily

Really convenient to quickly see if the workflows are passing or failing

Don't forget to set the image in the GitHub Container Registry to public, you can also bind the libretranslate GitHub repo to the libretranslate image in the GitHub Container Registry so that it is shown in the "Packages" section on the GitHub repo  

Have a nice holidays!