### PR TITLE
add support for auto language

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -299,6 +299,7 @@ document.addEventListener('DOMContentLoaded', function(){
 		  if (this.status >= 200 && this.status < 400) {
 			// Success!
 			self.langs = JSON.parse(this.response);
+			self.langs.push({ name: 'Auto (experimental)', code: 'auto' })
 			if (self.langs.length === 0){
 				self.loading = false;
 				self.error = "No languages available. Did you install the models correctly?"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-swagger==0.2.14
 flask-swagger-ui==3.36.0
 Flask-Limiter==1.4
 waitress==1.4.4
+langdetect


### PR DESCRIPTION
Not perfect, it picks a language not supported sometimes

It could be improved by using the function to get the list of most probable languages, then iterate to get the first we support

I also needed to manually add `auto` to the list of languages after getting it from Argos Translate

And I don't know why but it does not seems the default language have been updated even with this change:

```python
def create_app(char_limit=-1, req_limit=-1, ga_id=None, debug=False, frontend_language_source="auto", frontend_language_target="en"):
```