### PR TITLE
fix static package_data for offline mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     # packages=find_packages(include=['openpredict']),
     # package_dir={'openpredict': 'openpredict'},
-    package_data={'': ['static/*', 'templates/*']},
+    package_data={'': ['static/*', 'static/**/*', 'templates/*']},
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
package_data 'static/*'  won`t include sub directories so offline mode would result in 404 for static resources under js, css, fonts