### PR TITLE
Include language models into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
 FROM python:3.8
 
+ARG with_models=false
+
 WORKDIR /app
 
 RUN pip install --upgrade pip
 
 COPY . .
+
+# check for offline build
+RUN if [ "$with_models" = "true" ]; then  \
+        # install only the dependencies first
+        pip install -e .;  \
+        # initialize the language models
+        ./install_models.py;  \
+    fi
 
 # Install package from source code
 RUN pip install .

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Then open a web browser to http://localhost:5000
 ### Build with Docker
 
 ```bash
-docker build -t libretranslate .
+docker build [--build-arg with_models=true] -t libretranslate .
 ```
+
+If you want to run the Docker image in a complete offline environment, you need to add the `--build-arg with_models=true` parameter. Then the language models get downloaded during the build process of the image. Otherwise these models get downloaded on the first run of the image/container.
 
 Run the built image:
 


### PR DESCRIPTION
Hello,

normally an internet connection is required on the first run of the Docker image to download the language models. But if you got a complete offline Docker environment then you can't start the container.

So I modified the Dockerfile and added a build argument `with_models` (default: `false`). If it's set to `true`, the language models get downloaded during the image creation process. Afterwards the image is ready to go in an offline Docker environment.