### PR TITLE
Add option --load-only to set available languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ docker-compose up -d --build
 | --frontend-timeout | Set frontend translation timeout | `500`         |
 | --offline | Run user-interface entirely offline (don't use internet CDNs) | `false` |
 | --api-keys | Enable API keys database for per-user rate limits lookup | `Don't use API keys` |
+| --load-only   | Set available languages    | `all from argostranslate`    |
 
 ## Manage API Keys
 

--- a/app/app.py
+++ b/app/app.py
@@ -49,7 +49,7 @@ def get_routes_limits(default_req_limit, api_keys_db):
 def create_app(args):
     if not args.offline:
         from app.init import boot
-        boot()
+        boot(args.load_only)
 
     from app.language import languages
     app = Flask(__name__)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import argparse
+import operator
 from app.app import create_app
 
 def main():
@@ -29,6 +30,9 @@ def main():
                         help="Use offline")
     parser.add_argument('--api-keys', default=False, action="store_true",
                         help="Enable API keys database for per-user rate limits lookup")
+    parser.add_argument('--load-only', type=operator.methodcaller('split', ','),
+                        metavar='<comma-separated language codes>',
+                        help='Set available languages (ar,de,en,es,fr,ga,hi,it,ja,ko,pt,ru,zh)')
     
 
     args = parser.parse_args()


### PR DESCRIPTION
Add an option `--load-only` to the main parser, we give comma-separated language codes and it filters available packages from argostranslate to not install all packages but only the ones the user actually need.
The variable `load_only` will be a list of strings (language codes), or `None` by default in which case we do not filter available packages.
I also check that given language codes are available and that we did not discard all packages. Both would raise a ValueError.
It should close #51 
Any modification is welcome.