### PR TITLE
Programmatic api keys access

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ docker-compose up -d --build
 | --frontend-language-target | Set frontend default language - target | `es`          |
 | --frontend-timeout | Set frontend translation timeout | `500`         |
 | --api-keys | Enable API keys database for per-user rate limits lookup | `Don't use API keys` |
+| --require-api-key-origin | Require use of an API key for programmatic access to the API, unless the request origin matches this domain | `No restrictions on domain origin` |
 | --load-only   | Set available languages    | `all from argostranslate`    |
 
 ## Manage API Keys

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,8 @@ def main():
                         help='Set frontend translation timeout (%(default)s)')
     parser.add_argument('--api-keys', default=False, action="store_true",
                         help="Enable API keys database for per-user rate limits lookup")
+    parser.add_argument('--require-api-key-origin', type=str, default="",
+                        help="Require use of an API key for programmatic access to the API, unless the request origin matches this domain")
     parser.add_argument('--load-only', type=operator.methodcaller('split', ','),
                         metavar='<comma-separated language codes>',
                         help='Set available languages (ar,de,en,es,fr,ga,hi,it,ja,ko,pt,ru,zh)')


### PR DESCRIPTION
Flooding seems to continue even after flooding protection has been introduced. I suspect this is due to somebody having added a client side application in some app, somewhere, causing many IP addresses to flood the API. This is obviously not sustainable. 

I've added another layer of checking, whereby we allow the use of API calls to be made from an origin (e.g. libretranslate.com, but not from other clients). This is a simple check and can be spoofed, but should at least ﻿work for less determined offenders.
